### PR TITLE
Updated hlint-bounds

### DIFF
--- a/zifter-cabal/src/Zifter/Cabal.hs
+++ b/zifter-cabal/src/Zifter/Cabal.hs
@@ -34,7 +34,7 @@ cabalFormat = do
     rd <- getRootDir
     cabalFiles <-
         liftIO $
-        (filter (not . hidden) . filter ((".cabal" ==) . fileExtension) . snd) <$>
+        filter (not . hidden) . filter ((".cabal" ==) . fileExtension) . snd <$>
         listDirRecur rd
     forZ_ cabalFiles formatSingleCabalFile
 

--- a/zifter-hlint/package.yaml
+++ b/zifter-hlint/package.yaml
@@ -1,5 +1,5 @@
 name: zifter-hlint
-version: '0.1.0.0'
+version: '0.1.0.1'
 synopsis: zifter-hlint
 description: zifter-hlint
 category: Zift
@@ -11,7 +11,7 @@ homepage: http://cs-syd.eu
 dependencies:
 - base >=4.9 && <=5
 - filepath >=1.4 && <1.5
-- hlint >=1.9.35
+- hlint
 - path
 - path-io
 - safe >=0.3 && <0.4

--- a/zifter/src/Zifter.hs
+++ b/zifter/src/Zifter.hs
@@ -219,26 +219,22 @@ interpretZift = go
         efaa <- waitEither afaf aaf
         let complete fa a = pure $ fa <*> a
         case efaa of
-            Left far -> do
-                r <-
-                    case far of
-                        ZiftFailed s -> do
-                            cancel aaf
-                            pure $ ZiftFailed s
-                        _ -> do
-                            t2 <- wait aaf
-                            complete far t2
-                pure r
-            Right ar -> do
-                r <-
-                    case ar of
-                        ZiftFailed s -> do
-                            cancel afaf
-                            pure $ ZiftFailed s
-                        _ -> do
-                            t1 <- wait afaf
-                            complete t1 ar
-                pure r
+            Left far ->
+                case far of
+                    ZiftFailed s -> do
+                        cancel aaf
+                        pure $ ZiftFailed s
+                    _ -> do
+                        t2 <- wait aaf
+                        complete far t2
+            Right ar ->
+                case ar of
+                    ZiftFailed s -> do
+                        cancel afaf
+                        pure $ ZiftFailed s
+                    _ -> do
+                        t1 <- wait afaf
+                        complete t1 ar
     go rd (ZiftBind fa mb) = do
         ra <- go (rd {recursionList = L : recursionList rd}) fa
         case ra of

--- a/zifter/test/Zifter/Zift/Gen.hs
+++ b/zifter/test/Zifter/Zift/Gen.hs
@@ -51,8 +51,8 @@ instance GenUnchecked ZiftOutput
 
 instance (Validity a) => Validity (RGB a) where
     validate RGB {..} =
-        (delve "channelRed" channelRed) <> (delve "channelGreen" channelGreen) <>
-        (delve "channelBlue" channelBlue)
+        delve "channelRed" channelRed <> delve "channelGreen" channelGreen <>
+        delve "channelBlue" channelBlue
 
 instance (Ord a, Floating a, GenUnchecked a) => GenUnchecked (Colour a) where
     genUnchecked = sRGB24 <$> genUnchecked <*> genUnchecked <*> genUnchecked


### PR DESCRIPTION
Also checked whether this works with the latest hlint (2.1.5),
and all tests pass. However, I couldn't run the zifter-stack tests,
because they assume you're on a unix-based OS other than NixOS.